### PR TITLE
fix wikimedia/composer-merge-plugin version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "composer-plugin-api": "^1.1|^2.0",
         "laravel/framework": "~5.5|~6|~7",
-        "wikimedia/composer-merge-plugin": "dev-feature/composer-v2 as 1.5.0"
+        "wikimedia/composer-merge-plugin": "dev-feature/composer-v2 as 1.5.x-dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Aponta para a referecia correta do pacote cote wikimedia/composer-merge-plugin, pois ao instalar não esta encontrando o 1.5.0